### PR TITLE
Fixed compile error for linux/gcc9

### DIFF
--- a/itoa/int_to_chars_jeaiii.h
+++ b/itoa/int_to_chars_jeaiii.h
@@ -69,7 +69,7 @@ static const pair s_pairs[] = { P('0'), P('1'), P('2'), P('3'), P('4'), P('5'), 
 template<class T> inline T terminate(char* b) { return b; }
 template<> inline void terminate<void>(char* b) { *b = 0; }
 
-template<class RESULT = char*, class T, std::enable_if_t<(sizeof(T) <= sizeof(uint32_t))>* = 0>
+template<class RESULT = char*, class T, std::enable_if_t<(sizeof(T) <= sizeof(uint32_t))>* = nullptr>
 inline RESULT int_to_chars_jeaiii(T i, char* b)
 {
     uint64_t t;
@@ -77,7 +77,7 @@ inline RESULT int_to_chars_jeaiii(T i, char* b)
     return L09(LAST);
 }
 
-template<class RESULT = char*, class T, std::enable_if_t<(sizeof(T) == sizeof(uint64_t))>* = 0>
+template<class RESULT = char*, class T, std::enable_if_t<(sizeof(T) == sizeof(uint64_t))>* = nullptr>
 inline RESULT int_to_chars_jeaiii(T i, char* b)
 {
     uint64_t t;


### PR DESCRIPTION
Compile fails under linux gcc/9 due. Requires nullptr instead of 0.

```
g++ -ggdb -std=c++17    main.cpp   -o main
main.cpp: In function ‘void same(uint32_t)’:
main.cpp:66:17: error: no matching function for call to ‘int_to_chars_jeaiii<void>(uint32_t&, char [32])’
   66 |     itoa(n, text);
      |                 ^                           
In file included from main.cpp:51:
int_to_chars_jeaiii.h:73:15: note: candidate: ‘template<class RESULT, class T, std::enable_if_t<(sizeof (T) <= sizeof (unsigned int))>* <anonymous> > RESULT int_to_chars_jeaiii(T, char*)’
   73 | inline RESULT int_to_chars_jeaiii(T i, char* b)
      |               ^~~~~~~~~~~~~~~~~~~           
int_to_chars_jeaiii.h:73:15: note:   template argument deduction/substitution failed:
int_to_chars_jeaiii.h:72:94: error: conversion from ‘int’ to ‘void*’ in a converted constant expression
   72 | template<class RESULT = char*, class T, std::enable_if_t<(sizeof(T) <= sizeof(uint32_t))>* = 0>
      |                                                                                              ^  
int_to_chars_jeaiii.h:72:94: error: could not convert ‘0’ from ‘int’ to ‘void*’
int_to_chars_jeaiii.h:81:15: note: candidate: ‘template<class RESULT, class T, std::enable_if_t<(sizeof (T) == sizeof (long unsigned int))>* <anonymous> > RESULT int_to_chars_jeaiii(T, char*)’
   81 | inline RESULT int_to_chars_jeaiii(T i, char* b)
      |               ^~~~~~~~~~~~~~~~~~~           
int_to_chars_jeaiii.h:81:15: note:   template argument deduction/substitution failed:
In file included from /usr/include/c++/9/bits/move.h:55,
                 from /usr/include/c++/9/bits/nested_exception.h:40,
                 from /usr/include/c++/9/exception:144,
                 from /usr/include/c++/9/ios:39,
                 from /usr/include/c++/9/ostream:38, 
                 from /usr/include/c++/9/iostream:39,
                 from main.cpp:27:
/usr/include/c++/9/type_traits: In substitution of ‘template<bool _Cond, class _Tp> using enable_if_t = typename std::enable_if::type [with bool _Cond = (sizeof (unsigned int) == sizeof (long unsigned int)); 
_Tp = void]’:
int_to_chars_jeaiii.h:80:94:   required from here
/usr/include/c++/9/type_traits:2384:11: error: no type named ‘type’ in ‘struct std::enable_if<false, void>’
 2384 |     using enable_if_t = typename enable_if<_Cond, _Tp>::type;
      |           ^~~~~~~~~~~
```                       