### PR TITLE
Replace C++17 hex-float literal with bitshifts

### DIFF
--- a/include/itoa/jeaiii_to_text.h
+++ b/include/itoa/jeaiii_to_text.h
@@ -99,14 +99,14 @@ namespace jeaiii
         {
             if (n < u32(1e4))
             {
-                auto f0 = u32(10 * 0x1p24 / 1e3 + 1) * n;
+                auto f0 = u32(10 * (1 << 24) / 1e3 + 1) * n;
                 *reinterpret_cast<pair*>(b) = digits.fd[f0 >> 24];
                 b -= n < u32(1e3);
                 auto f2 = (f0 & mask24) * 100;
                 *reinterpret_cast<pair*>(b + 2) = digits.dd[f2 >> 24];
                 return b + 4;
             }
-            auto f0 = u64(10 * 0x1p32 / 1e5 + 1) * n;
+            auto f0 = u64(10 * (1ull << 32ull)/ 1e5 + 1) * n;
             *reinterpret_cast<pair*>(b) = digits.fd[f0 >> 32];
             b -= n < u32(1e5);
             auto f2 = (f0 & mask32) * 100;
@@ -115,11 +115,11 @@ namespace jeaiii
             *reinterpret_cast<pair*>(b + 4) = digits.dd[f4 >> 32];
             return b + 6;
         }
-        if (n < u64(0x1p32))
+        if (n < u64(1ull << 32ull))
         {
             if (n < u32(1e8))
             {
-                auto f0 = u64(10 * 0x1p48 / 1e7 + 1) * n >> 16;
+                auto f0 = u64(10 * (1ull << 48ull) / 1e7 + 1) * n >> 16;
                 *reinterpret_cast<pair*>(b) = digits.fd[f0 >> 32];
                 b -= n < u32(1e7);
                 auto f2 = (f0 & mask32) * 100;
@@ -130,7 +130,7 @@ namespace jeaiii
                 *reinterpret_cast<pair*>(b + 6) = digits.dd[f6 >> 32];
                 return b + 8;
             }
-            auto f0 = u64(10 * 0x1p57 / 1e9 + 1) * n;
+            auto f0 = u64(10 * (1ull << 57ull) / 1e9 + 1) * n;
             *reinterpret_cast<pair*>(b) = digits.fd[f0 >> 57];
             b -= n < u32(1e9);
             auto f2 = (f0 & mask57) * 100;
@@ -158,7 +158,7 @@ namespace jeaiii
         {
             if (u < u32(1e4))
             {
-                auto f0 = u32(10 * 0x1p24 / 1e3 + 1) * u;
+                auto f0 = u32(10 * (1 << 24) / 1e3 + 1) * u;
                 *reinterpret_cast<pair*>(b) = digits.fd[f0 >> 24];
                 b -= u < u32(1e3);
                 auto f2 = (f0 & mask24) * 100;
@@ -167,7 +167,7 @@ namespace jeaiii
             }
             else
             {
-                auto f0 = u64(10 * 0x1p32 / 1e5 + 1) * u;
+                auto f0 = u64(10 * (1ull << 32ull) / 1e5 + 1) * u;
                 *reinterpret_cast<pair*>(b) = digits.fd[f0 >> 32];
                 b -= u < u32(1e5);
                 auto f2 = (f0 & mask32) * 100;
@@ -179,7 +179,7 @@ namespace jeaiii
         }
         else if (u < u32(1e8))
         {
-            auto f0 = u64(10 * 0x1p48 / 1e7 + 1) * u >> 16;
+            auto f0 = u64(10 * (1ull << 48ull) / 1e7 + 1) * u >> 16;
             *reinterpret_cast<pair*>(b) = digits.fd[f0 >> 32];
             b -= u < u32(1e7);
             auto f2 = (f0 & mask32) * 100;
@@ -190,9 +190,9 @@ namespace jeaiii
             *reinterpret_cast<pair*>(b + 6) = digits.dd[f6 >> 32];
             b += 8;
         }
-        else if (u < u64(0x1p32))
+        else if (u < u64(1ull << 32ull))
         {
-            auto f0 = u64(10 * 0x1p57 / 1e9 + 1) * u;
+            auto f0 = u64(10 * (1ull << 57ull) / 1e9 + 1) * u;
             *reinterpret_cast<pair*>(b) = digits.fd[f0 >> 57];
             b -= u < u32(1e9);
             auto f2 = (f0 & mask57) * 100;
@@ -218,7 +218,7 @@ namespace jeaiii
             }
             else
             {
-                auto f0 = u32(10 * 0x1p24 / 1e3 + 1) * u;
+                auto f0 = u32(10 * (1 << 24) / 1e3 + 1) * u;
                 *reinterpret_cast<pair*>(b) = digits.fd[f0 >> 24];
                 b -= u < u32(1e3);
                 auto f2 = (f0 & mask24) * 100;
@@ -226,7 +226,7 @@ namespace jeaiii
                 b += 4;
             }
             // do 8 digits
-            auto f0 = (u64(0x1p48 / 1e6 + 1) * y >> 16) + 1;
+            auto f0 = (u64((1ull << 48ull) / 1e6 + 1) * y >> 16) + 1;
             *reinterpret_cast<pair*>(b) = digits.dd[f0 >> 32];
             auto f2 = (f0 & mask32) * 100;
             *reinterpret_cast<pair*>(b + 2) = digits.dd[f2 >> 32];
@@ -237,7 +237,7 @@ namespace jeaiii
             b += 8;
         }
         // do 8 digits
-        auto f0 = (u64(0x1p48 / 1e6 + 1) * z >> 16) + 1;
+        auto f0 = (u64((1ull << 48ull) / 1e6 + 1) * z >> 16) + 1;
         *reinterpret_cast<pair*>(b) = digits.dd[f0 >> 32];
         auto f2 = (f0 & mask32) * 100;
         *reinterpret_cast<pair*>(b + 2) = digits.dd[f2 >> 32];

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -26,6 +26,7 @@ SOFTWARE.
 #include <stdlib.h>
 #include <iostream>
 #include <string>
+#include <random>
 
 #include "../include/itoa/jeaiii_to_text.h"
 
@@ -67,6 +68,7 @@ void show(T n) {
     std::cout << text << "\n";
 }
 
+
 int main()
 {
 #if 0
@@ -74,6 +76,25 @@ int main()
     do {
         uint32_t n = uint32_t(i);
         same(n);
+        i += 1;
+    } while (i < 1ULL << 32);
+#endif
+
+#if 0
+    // Eausted tests for 64bits are impossible,
+    // so test upper 32bits only
+    // TODO: fill lower 32bits with random value
+    uint64_t i = 0;
+    uint64_t tick = 1024*1024*16;
+    do {
+        uint64_t n = (i << 32);
+        same(n);
+        if ((i % tick) == 0) {
+           std::cout << n << " ";
+           show(n);
+          
+           std::cout << "tested " << i << " of " << (1ull << 32ull) << "\n";
+        }
         i += 1;
     } while (i < 1ULL << 32);
 #endif


### PR DESCRIPTION
Thank you for the nice library!

This PR enables compilation with C++11 compiler(tested with `clang++ -std=c++11`).

Also, added more tests(disabled by default). On my local run I've confirmed the test passes.
